### PR TITLE
Mechanical Parts mk04 Balance

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -130,22 +130,29 @@ local recipes_list =
   "brake-mk01",
   "brake-mk02",
   "brake-mk03",
+  "brake-mk04",
   "controler-mk01",
   "controler-mk02",
   "controler-mk03",
+  "controler-mk04",
   "gearbox-mk01",
   "gearbox-mk02",
   "gearbox-mk03",
+  "gearbox-mk04",
   "shaft-mk01",
   -- "shaft-mk02", casting unit doesn't use prod
-  -- "shaft-mk03", casting unit doesn't use prod
+  -- "shaft-mk03",
+  -- "shaft-mk04",
   "utility-box-mk01",
   "utility-box-mk02",
   "utility-box-mk03",
+  "utility-box-mk04",
   "mechanical-parts-01",
   "mechanical-parts-02",
   "mechanical-parts-03",
+  "mechanical-parts-04",
   "hydraulic-system-mk01",
+  "hydraulic-system-mk02",
 }
 
 --adding to module limitation list


### PR DESCRIPTION
Mechanical parts mk04 are obviously looney toons in cost, but "only" represent 27% of the space science pack according to YAFC. So just gonna let that one be after adding prod to the intermediates.