### PR TITLE
Advanced silicon wafers productivity

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -166,6 +166,15 @@ local recipes_list =
 --   "cf2",
 --   "dry-cf",
   "cf",
+  -- Silicon Chain
+  -- "crucible",
+  -- "polycrystalline-slab",
+  "polycrystalline-plate",
+  "silicon-wafer-2",
+  -- "quartz-crucible",
+  -- "monocrystalline-slab",
+  "monocrystalline-plate",
+  "silicon-wafer-3",
 }
 
 --adding to module limitation list


### PR DESCRIPTION
Adding productivity to the more advanced silicon wafers recipes to match the base recipe.

Base: (unchanged)
![image](https://user-images.githubusercontent.com/49283746/194593600-e8c11004-b1db-45a5-b754-8fbec28a0b6f.png)

Poly old:
![image](https://user-images.githubusercontent.com/49283746/194593680-b39e9389-173d-4171-874d-77e018fe51bd.png)

Poly new:
![image](https://user-images.githubusercontent.com/49283746/194593734-d7a5c16b-81b5-40c7-be96-05557b5a948d.png)

Mono old:
![image](https://user-images.githubusercontent.com/49283746/194593783-1b4b83c2-4517-44c0-bc01-8fdeab68baef.png)

Mono new:
![image](https://user-images.githubusercontent.com/49283746/194593810-01b3c7b2-ca6d-4619-aeea-be776d076132.png)
