### PR TITLE
Antimony Drill and Geo Plant circuit connections

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -10,6 +10,10 @@ require('prototypes/fuel-categories')
 require("prototypes/module-categories")
 -- ))
 
+-- (( Circuit Connector Definitions )) --
+require('prototypes/circuit-connector-definitions')
+-- ))
+
 -- (( Technology ))--
 require("prototypes.technologies.antimony")
 require("prototypes.technologies.silicon")

--- a/prototypes/buildings/antimonium-drill-mk01.lua
+++ b/prototypes/buildings/antimonium-drill-mk01.lua
@@ -64,6 +64,13 @@ ENTITY {
         width = 12,
         height = 12
     },
+
+    require ("__pyalternativeenergy__/prototypes/circuit-connector-definitions-pyae"),
+
+    circuit_wire_connection_points = antimonium_drill_connector_definitions.points,
+    circuit_connector_sprites = antimonium_drill_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+
     animations = {
         layers = {
             {

--- a/prototypes/buildings/antimonium-drill-mk01.lua
+++ b/prototypes/buildings/antimonium-drill-mk01.lua
@@ -64,13 +64,9 @@ ENTITY {
         width = 12,
         height = 12
     },
-
-    require ("__pyalternativeenergy__/prototypes/circuit-connector-definitions-pyae"),
-
-    circuit_wire_connection_points = antimonium_drill_connector_definitions.points,
-    circuit_connector_sprites = antimonium_drill_connector_definitions.sprites,
+    circuit_wire_connection_points = circuit_connector_definitions["antimonium-drill-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["antimonium-drill-mkxx"].sprites,
     circuit_wire_max_distance = default_circuit_wire_max_distance,
-
     animations = {
         layers = {
             {

--- a/prototypes/buildings/antimonium-drill-mk02.lua
+++ b/prototypes/buildings/antimonium-drill-mk02.lua
@@ -68,6 +68,13 @@ ENTITY {
         width = 12,
         height = 12
     },
+
+    require ("__pyalternativeenergy__/prototypes/circuit-connector-definitions-pyae"),
+
+    circuit_wire_connection_points = antimonium_drill_connector_definitions.points,
+    circuit_connector_sprites = antimonium_drill_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+
     animations = {
         layers = {
             {

--- a/prototypes/buildings/antimonium-drill-mk02.lua
+++ b/prototypes/buildings/antimonium-drill-mk02.lua
@@ -68,13 +68,9 @@ ENTITY {
         width = 12,
         height = 12
     },
-
-    require ("__pyalternativeenergy__/prototypes/circuit-connector-definitions-pyae"),
-
-    circuit_wire_connection_points = antimonium_drill_connector_definitions.points,
-    circuit_connector_sprites = antimonium_drill_connector_definitions.sprites,
+    circuit_wire_connection_points = circuit_connector_definitions["antimonium-drill-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["antimonium-drill-mkxx"].sprites,
     circuit_wire_max_distance = default_circuit_wire_max_distance,
-
     animations = {
         layers = {
             {

--- a/prototypes/buildings/antimonium-drill-mk03.lua
+++ b/prototypes/buildings/antimonium-drill-mk03.lua
@@ -68,6 +68,13 @@ ENTITY {
         width = 12,
         height = 12
     },
+
+    require ("__pyalternativeenergy__/prototypes/circuit-connector-definitions-pyae"),
+
+    circuit_wire_connection_points = antimonium_drill_connector_definitions.points,
+    circuit_connector_sprites = antimonium_drill_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+
     animations = {
         layers = {
             {

--- a/prototypes/buildings/antimonium-drill-mk03.lua
+++ b/prototypes/buildings/antimonium-drill-mk03.lua
@@ -68,13 +68,9 @@ ENTITY {
         width = 12,
         height = 12
     },
-
-    require ("__pyalternativeenergy__/prototypes/circuit-connector-definitions-pyae"),
-
-    circuit_wire_connection_points = antimonium_drill_connector_definitions.points,
-    circuit_connector_sprites = antimonium_drill_connector_definitions.sprites,
+    circuit_wire_connection_points = circuit_connector_definitions["antimonium-drill-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["antimonium-drill-mkxx"].sprites,
     circuit_wire_max_distance = default_circuit_wire_max_distance,
-
     animations = {
         layers = {
             {

--- a/prototypes/buildings/antimonium-drill-mk04.lua
+++ b/prototypes/buildings/antimonium-drill-mk04.lua
@@ -71,6 +71,13 @@ ENTITY {
         width = 12,
         height = 12
     },
+
+    require ("__pyalternativeenergy__/prototypes/circuit-connector-definitions-pyae"),
+
+    circuit_wire_connection_points = antimonium_drill_connector_definitions.points,
+    circuit_connector_sprites = antimonium_drill_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+
     animations = {
         layers = {
             {

--- a/prototypes/buildings/antimonium-drill-mk04.lua
+++ b/prototypes/buildings/antimonium-drill-mk04.lua
@@ -71,13 +71,9 @@ ENTITY {
         width = 12,
         height = 12
     },
-
-    require ("__pyalternativeenergy__/prototypes/circuit-connector-definitions-pyae"),
-
-    circuit_wire_connection_points = antimonium_drill_connector_definitions.points,
-    circuit_connector_sprites = antimonium_drill_connector_definitions.sprites,
+    circuit_wire_connection_points = circuit_connector_definitions["antimonium-drill-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["antimonium-drill-mkxx"].sprites,
     circuit_wire_max_distance = default_circuit_wire_max_distance,
-
     animations = {
         layers = {
             {

--- a/prototypes/buildings/geothermal-plant-mk01.lua
+++ b/prototypes/buildings/geothermal-plant-mk01.lua
@@ -84,6 +84,13 @@ ENTITY {
     },
     monitor_visualization_tint = {r=78, g=173, b=255},
     --base_render_layer = "lower-object-above-shadow",
+
+    require ("__pyalternativeenergy__/prototypes/circuit-connector-definitions-pyae"),
+
+    circuit_wire_connection_points = geothermal_plant_connector_definitions.points,
+    circuit_connector_sprites = geothermal_plant_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+
     animations = {
       layers = {
           {

--- a/prototypes/buildings/geothermal-plant-mk01.lua
+++ b/prototypes/buildings/geothermal-plant-mk01.lua
@@ -84,13 +84,9 @@ ENTITY {
     },
     monitor_visualization_tint = {r=78, g=173, b=255},
     --base_render_layer = "lower-object-above-shadow",
-
-    require ("__pyalternativeenergy__/prototypes/circuit-connector-definitions-pyae"),
-
-    circuit_wire_connection_points = geothermal_plant_connector_definitions.points,
-    circuit_connector_sprites = geothermal_plant_connector_definitions.sprites,
+    circuit_wire_connection_points = circuit_connector_definitions["geothermal-plant-mk01"].points,
+    circuit_connector_sprites = circuit_connector_definitions["geothermal-plant-mk01"].sprites,
     circuit_wire_max_distance = default_circuit_wire_max_distance,
-
     animations = {
       layers = {
           {

--- a/prototypes/circuit-connector-definitions-pyae.lua
+++ b/prototypes/circuit-connector-definitions-pyae.lua
@@ -1,0 +1,24 @@
+-- Holds circuit connection definitions for PyAE entities.
+-- variation counts from 0 (Python-like).
+
+antimonium_drill_connector_definitions = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 27, main_offset = util.by_pixel(33, 8), shadow_offset = util.by_pixel(27, 20), show_shadow = false }, 
+    { variation = 27, main_offset = util.by_pixel(33, 8), shadow_offset = util.by_pixel(27, 20), show_shadow = false },
+    { variation = 27, main_offset = util.by_pixel(33, 8), shadow_offset = util.by_pixel(27, 20), show_shadow = false },
+    { variation = 27, main_offset = util.by_pixel(33, 8), shadow_offset = util.by_pixel(27, 20), show_shadow = false }
+  }
+)
+
+geothermal_plant_connector_definitions = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {
+    { variation = 26, main_offset = util.by_pixel(60, 155), shadow_offset = util.by_pixel(54, 167), show_shadow = false }, 
+    { variation = 26, main_offset = util.by_pixel(60, 155), shadow_offset = util.by_pixel(54, 167), show_shadow = false },
+    { variation = 26, main_offset = util.by_pixel(60, 155), shadow_offset = util.by_pixel(54, 167), show_shadow = false },
+    { variation = 26, main_offset = util.by_pixel(60, 155), shadow_offset = util.by_pixel(54, 167), show_shadow = false }
+  }
+)

--- a/prototypes/circuit-connector-definitions-pyae.lua
+++ b/prototypes/circuit-connector-definitions-pyae.lua
@@ -5,10 +5,10 @@ antimonium_drill_connector_definitions = circuit_connector_definitions.create
 (
   universal_connector_template,
   {--Directions are up, right, down, left.
-    { variation = 27, main_offset = util.by_pixel(33, 8), shadow_offset = util.by_pixel(27, 20), show_shadow = false }, 
-    { variation = 27, main_offset = util.by_pixel(33, 8), shadow_offset = util.by_pixel(27, 20), show_shadow = false },
-    { variation = 27, main_offset = util.by_pixel(33, 8), shadow_offset = util.by_pixel(27, 20), show_shadow = false },
-    { variation = 27, main_offset = util.by_pixel(33, 8), shadow_offset = util.by_pixel(27, 20), show_shadow = false }
+    { variation = 23, main_offset = util.by_pixel(65, -24), shadow_offset = util.by_pixel(59, -12), show_shadow = false },
+    { variation = 23, main_offset = util.by_pixel(65, -24), shadow_offset = util.by_pixel(59, -12), show_shadow = false },
+    { variation = 23, main_offset = util.by_pixel(65, -24), shadow_offset = util.by_pixel(59, -12), show_shadow = false },
+    { variation = 23, main_offset = util.by_pixel(65, -24), shadow_offset = util.by_pixel(59, -12), show_shadow = false }
   }
 )
 
@@ -16,7 +16,7 @@ geothermal_plant_connector_definitions = circuit_connector_definitions.create
 (
   universal_connector_template,
   {
-    { variation = 26, main_offset = util.by_pixel(60, 155), shadow_offset = util.by_pixel(54, 167), show_shadow = false }, 
+    { variation = 26, main_offset = util.by_pixel(60, 155), shadow_offset = util.by_pixel(54, 167), show_shadow = false },
     { variation = 26, main_offset = util.by_pixel(60, 155), shadow_offset = util.by_pixel(54, 167), show_shadow = false },
     { variation = 26, main_offset = util.by_pixel(60, 155), shadow_offset = util.by_pixel(54, 167), show_shadow = false },
     { variation = 26, main_offset = util.by_pixel(60, 155), shadow_offset = util.by_pixel(54, 167), show_shadow = false }

--- a/prototypes/circuit-connector-definitions.lua
+++ b/prototypes/circuit-connector-definitions.lua
@@ -1,7 +1,7 @@
 -- Holds circuit connection definitions for PyAE entities.
 -- variation counts from 0 (Python-like).
 
-antimonium_drill_connector_definitions = circuit_connector_definitions.create
+circuit_connector_definitions["antimonium-drill-mkxx"] = circuit_connector_definitions.create
 (
   universal_connector_template,
   {--Directions are up, right, down, left.
@@ -12,7 +12,7 @@ antimonium_drill_connector_definitions = circuit_connector_definitions.create
   }
 )
 
-geothermal_plant_connector_definitions = circuit_connector_definitions.create
+circuit_connector_definitions["geothermal-plant-mk01"] = circuit_connector_definitions.create
 (
   universal_connector_template,
   {


### PR DESCRIPTION
This PR adds circuit connectivity to all four Mks. of Antimony Drill and the Geothermal Plant, allowing them to output available resources as a signal. These pull appropriate definitions from the `circuit-connector-definitions` file in the parent directory.