### PR TITLE
Fix GUI crash when entity is not defined

### DIFF
--- a/scripts/microwave-receiver.lua
+++ b/scripts/microwave-receiver.lua
@@ -62,7 +62,7 @@ end
 Microwave_Receiver.events.on_gui_opened = function(event)
 	local player = game.get_player(event.player_index)
 	local entity = event.entity
-	if event.gui_type ~= defines.gui_type.entity or entity.name ~= 'microwave-receiver' then return end
+	if event.gui_type ~= defines.gui_type.entity or not entity or entity.name ~= 'microwave-receiver' then return end
 
 	local main_frame = player.gui.screen.add{type = 'frame', name = 'microwave_receiver_gui', caption = entity.prototype.localised_name, direction = 'vertical'}
 	main_frame.style.width = 340

--- a/scripts/thermosolar/heliostat.lua
+++ b/scripts/thermosolar/heliostat.lua
@@ -97,7 +97,7 @@ end
 Heliostat.events.on_gui_opened = function(event)
 	local player = game.get_player(event.player_index)
 	local entity = event.entity
-	if event.gui_type ~= defines.gui_type.entity or entity.name ~= 'solar-tower-building' then return end
+	if event.gui_type ~= defines.gui_type.entity or not entity or entity.name ~= 'solar-tower-building' then return end
 
 	local main_frame = player.gui.screen.add{type = 'frame', name = 'heliostat_gui', caption = entity.prototype.localised_name, direction = 'vertical'}
 	main_frame.tags = {unit_number = entity.unit_number}

--- a/scripts/thermosolar/solar-updraft-tower.lua
+++ b/scripts/thermosolar/solar-updraft-tower.lua
@@ -146,7 +146,7 @@ end
 Solar_Updraft_Tower.events.on_gui_opened = function(event)
 	local player = game.get_player(event.player_index)
 	local entity = event.entity
-	if event.gui_type ~= defines.gui_type.entity or entity.name ~= 'sut' then return end
+	if event.gui_type ~= defines.gui_type.entity or not entity or entity.name ~= 'sut' then return end
 
 	local main_frame = player.gui.screen.add{type = 'frame', name = 'sut_gui', caption = entity.prototype.localised_name, direction = 'vertical'}
 	main_frame.tags = {unit_number = entity.unit_number}


### PR DESCRIPTION
pyAE caused a runtime crash when other mods' GUI didn't involve a physical entity.
Added a entity check to the return conditions