### PR TITLE
Expanded Geothermal Plant output fluid box

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ Date: ?
     - removing voiding recipe for neutrons in py sinkhole. use neutron absorber instead
     - neutron voiding recipe slowed down from 0.5s -> 50s
     - adjusted pipe connections for neutron absorber
+    - expanded output fluid box for Geothermal Plant (https://github.com/pyanodon/pybugreports/issues/323) (credit: JStMorgan)
 ---------------------------------------------------------------------------------------------------
 Version: 1.2.6
 Date: 2023-9-3

--- a/prototypes/buildings/geothermal-plant-mk01.lua
+++ b/prototypes/buildings/geothermal-plant-mk01.lua
@@ -63,7 +63,7 @@ ENTITY {
   },
     output_fluid_box =
     {
-      base_area = 1,
+      base_area = 10,
       base_level = 1,
       pipe_covers = DATA.Pipes.covers(false, true, true, true),
       pipe_connections =


### PR DESCRIPTION
Partly addresses pyanodon/pybugreports#323 .

A small PR to expand the Geothermal Plant's `output_fluid_box` from 1 to 10 (as used for the vanilla Pumpjack) to make it play nice with mining productivity bonuses.