### PR TITLE
Fix a typo in Yellowcake isotope separation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Date: ???
   Fixes:
     - buffed # of pipe connections on mk3 turbine from 4->8    (https://github.com/pyanodon/pybugreports/issues/407)
     - buffed # of pipe connections on mk4 turbine from 4->16   (https://github.com/pyanodon/pybugreports/issues/407)
+    - fixed a typo in Yellowcake isotope seperation -> separation
 ---------------------------------------------------------------------------------------------------
 Version: 1.2.16
 Date: 2024-1-29

--- a/locale/en/recipe.cfg
+++ b/locale/en/recipe.cfg
@@ -4,7 +4,7 @@ mova-washing=Wash Movas
 
 uf6=Uranium hexafluoride __1__%
 depleted-uf6=Uranium hexafluoride __1__%
-split-yellowcake=Yellowcake isotope seperation
+split-yellowcake=Yellowcake isotope separation
 neutron-absorbston=Neutron absorption
 [recipe-description]
 split-yellowcake=Needs more frosting.


### PR DESCRIPTION
https://en.wiktionary.org/wiki/seperation
> Misspelling of [separation](https://en.wiktionary.org/wiki/separation#English).