### PR TITLE
Tailings & Muddy Water Internal Name Change

### DIFF
--- a/prototypes/fluids/r1.lua
+++ b/prototypes/fluids/r1.lua
@@ -11,7 +11,7 @@ RECIPE {
     },
     results = {
         {type = "fluid", name = "r1",                amount = 100},
-        {type = "fluid", name = "dirty-water-heavy", amount = 50},
+        {type = "fluid", name = "tailings", amount = 50},
     },
     main_product = "r1",
 }:add_unlock("lithium-processing")

--- a/prototypes/fluids/r2.lua
+++ b/prototypes/fluids/r2.lua
@@ -10,7 +10,7 @@ RECIPE {
     },
     results = {
         {type = "fluid", name = "r2",                amount = 50},
-        {type = "fluid", name = "dirty-water-heavy", amount = 50},
+        {type = "fluid", name = "tailings", amount = 50},
     },
     main_product = "r2",
 }:add_unlock("lithium-processing")

--- a/prototypes/recipes/mirrors.lua
+++ b/prototypes/recipes/mirrors.lua
@@ -87,7 +87,7 @@ RECIPE {
     },
     results = {
         {type = "item",  name = "clean-glass-sheet", amount = 1},
-        {type = "fluid", name = "dirty-water-light", amount = 100},
+        {type = "fluid", name = "muddy-sludge", amount = 100},
     },
     main_product = "clean-glass-sheet",
     icon = "__pyalternativeenergygraphics__/graphics/icons/polished-glass-washer.png",

--- a/prototypes/recipes/mova/mova-processing.lua
+++ b/prototypes/recipes/mova/mova-processing.lua
@@ -10,7 +10,7 @@ RECIPE {
     },
     results = {
         {type = "item",  name = "washed-mova",       amount = 10},
-        {type = "fluid", name = "dirty-water-light", amount = 100}
+        {type = "fluid", name = "muddy-sludge", amount = 100}
     },
     main_product = "washed-mova",
     icon = "__pyalternativeenergygraphics__/graphics/icons/wash-mova.png",

--- a/prototypes/recipes/nano-mesh.lua
+++ b/prototypes/recipes/nano-mesh.lua
@@ -63,7 +63,7 @@ RECIPE {
     },
     results = {
         {type = "item",  name = "guhcl",             amount = 1},
-        {type = "fluid", name = "dirty-water-light", amount = 100},
+        {type = "fluid", name = "muddy-sludge", amount = 100},
     },
     main_product = "guhcl",
 }:add_unlock("nano-mesh")

--- a/prototypes/recipes/recipes-carbonfiber.lua
+++ b/prototypes/recipes/recipes-carbonfiber.lua
@@ -155,7 +155,7 @@ RECIPE {
     },
     results = {
         {type = "item",  name = "cf2",               amount = 1},
-        {type = "fluid", name = "dirty-water-heavy", amount = 50},
+        {type = "fluid", name = "tailings", amount = 50},
     },
     main_product = "cf2",
 }:add_unlock("carbon-fiber")

--- a/prototypes/recipes/recipes-er.lua
+++ b/prototypes/recipes/recipes-er.lua
@@ -43,7 +43,7 @@ RECIPE {
     },
     results = {
         {type = "item",  name = "er-oxide",          amount = 1},
-        {type = "fluid", name = "dirty-water-heavy", amount = 100},
+        {type = "fluid", name = "tailings", amount = 100},
 
     },
     main_product = "er-oxide",

--- a/prototypes/recipes/recipes-eva.lua
+++ b/prototypes/recipes/recipes-eva.lua
@@ -79,7 +79,7 @@ RECIPE {
     },
     results = {
         {type = "fluid", name = "vinyl-acetate",     amount = 50},
-        {type = "fluid", name = "dirty-water-heavy", amount = 100},
+        {type = "fluid", name = "tailings", amount = 100},
         {type = "fluid", name = "carbon-dioxide",    amount = 50},
     },
     main_product = "vinyl-acetate",

--- a/prototypes/recipes/recipes-gd.lua
+++ b/prototypes/recipes/recipes-gd.lua
@@ -29,7 +29,7 @@ RECIPE {
     },
     results = {
         {type = "item",  name = "re-precipitate-01", amount = 1},
-        {type = "fluid", name = "dirty-water-light", amount = 50},
+        {type = "fluid", name = "muddy-sludge", amount = 50},
     },
     main_product = "re-precipitate-01",
 }:add_unlock("rare-earth-tech-mk02")
@@ -166,7 +166,7 @@ RECIPE {
     },
     results = {
         {type = "item",  name = "th-oxide",          amount = 2},
-        {type = "fluid", name = "dirty-water-light", amount = 50},
+        {type = "fluid", name = "muddy-sludge", amount = 50},
     },
     main_product = "th-oxide",
 }:add_unlock("thorium")
@@ -202,7 +202,7 @@ RECIPE {
     },
     results = {
         {type = "item",  name = "gd-oxalate",        amount = 1},
-        {type = "fluid", name = "dirty-water-light", amount = 100},
+        {type = "fluid", name = "muddy-sludge", amount = 100},
     },
     main_product = "gd-oxalate",
 }:add_unlock("gadolinium")

--- a/prototypes/recipes/recipes-sb.lua
+++ b/prototypes/recipes/recipes-sb.lua
@@ -247,7 +247,7 @@ RECIPE {
         {type = "fluid", name = "kerosene",      amount = 50},
     },
     results = {
-        {type = "fluid", name = "dirty-water-heavy", amount = 100},
+        {type = "fluid", name = "tailings", amount = 100},
         {type = "fluid", name = "sb-low-conc",       amount = 50},
     },
     main_product = "sb-low-conc",
@@ -319,7 +319,7 @@ RECIPE {
     },
     results = {
         {type = "fluid", name = "sb-final-conc",     amount = 100},
-        {type = "fluid", name = "dirty-water-heavy", amount = 100},
+        {type = "fluid", name = "tailings", amount = 100},
     },
     main_product = "sb-final-conc",
 }:add_unlock("antimony-mk04")
@@ -336,7 +336,7 @@ RECIPE {
     },
     results = {
         {type = "fluid", name = "sb-conc",           amount = 100},
-        {type = "fluid", name = "dirty-water-heavy", amount = 100},
+        {type = "fluid", name = "tailings", amount = 100},
     },
     main_product = "sb-conc",
 }:add_unlock("antimony-mk04")

--- a/prototypes/recipes/recipes.lua
+++ b/prototypes/recipes/recipes.lua
@@ -1054,7 +1054,7 @@ RECIPE {
     },
     results = {
         {type = "item",  name = "washed-ash",        amount = 5},
-        {type = "fluid", name = "dirty-water-light", amount = 50},
+        {type = "fluid", name = "muddy-sludge", amount = 50},
     },
     main_product = "washed-ash",
 }:add_unlock("py-science-pack-mk03")
@@ -1107,7 +1107,7 @@ RECIPE {
     },
     results = {
         {type = "item",  name = "bio-ore",           amount = 1},
-        {type = "fluid", name = "dirty-water-light", amount = 50},
+        {type = "fluid", name = "muddy-sludge", amount = 50},
     },
     main_product = "bio-ore",
 }:add_unlock("py-science-pack-mk03")

--- a/prototypes/recipes/recycling-recipes.lua
+++ b/prototypes/recipes/recycling-recipes.lua
@@ -89,10 +89,10 @@ RECIPE {
         {type = "item",  name = "gravel",   amount = 1},
     },
     results = {
-        {type = "fluid", name = "dirty-water-heavy", amount = 50},
+        {type = "fluid", name = "tailings", amount = 50},
     },
     allow_productivity = true,
-    main_product = "dirty-water-heavy"
+    main_product = "tailings"
 }:add_unlock("advanced-mining-facilities")
 
 --limestone
@@ -163,7 +163,7 @@ RECIPE {
     enabled = false,
     energy_required = 3,
     ingredients = {
-        {type = "fluid", name = "dirty-water-light", amount = 100},
+        {type = "fluid", name = "muddy-sludge", amount = 100},
     },
     results = {
         {type = "fluid", name = "water",  amount = 100},
@@ -182,7 +182,7 @@ RECIPE {
     energy_required = 5.5,
     ingredients = {
         {type = "item",  name = "filtration-media",  amount = 1},
-        {type = "fluid", name = "dirty-water-light", amount = 500}
+        {type = "fluid", name = "muddy-sludge", amount = 500}
     },
     results = {
         {type = "fluid", name = "water", amount = 500},
@@ -745,7 +745,7 @@ RECIPE {
         {type = "item",  name = "sand",    amount = 1},
     },
     results = {
-        {type = "fluid", name = "dirty-water-heavy", amount = 200},
+        {type = "fluid", name = "tailings", amount = 200},
         {type = "item",  name = "oil-sand",          amount = 3},
     },
     main_product = "oil-sand",
@@ -765,9 +765,9 @@ RECIPE {
         {type = "item",  name = "pure-sand",   amount = 10}
     },
     results = {
-        {type = "fluid", name = "dirty-water-light", amount = 150}
+        {type = "fluid", name = "muddy-sludge", amount = 150}
     },
-    main_product = "dirty-water-light",
+    main_product = "muddy-sludge",
     allow_productivity = true,
 }:add_unlock("filtration")
 

--- a/prototypes/updates/pycoalprocessing-updates.lua
+++ b/prototypes/updates/pycoalprocessing-updates.lua
@@ -170,7 +170,7 @@ RECIPE {
     order = "c"
 }:add_unlock("excavation-2")
 
-FLUID("dirty-water-light"):subgroup_order("py-alternativeenergy-fluids", "c")
+FLUID("muddy-sludge"):subgroup_order("py-alternativeenergy-fluids", "c")
 
 --pycp
 data.raw["assembling-machine"]["solid-separator-mk02"].energy_usage = "3MW"

--- a/todo.txt
+++ b/todo.txt
@@ -19,7 +19,6 @@ CODING:
 
 FYI:
 
-- there is no more "dirty-water". there is dirty-water-light (mud) and dirty-water-heavy(normal tailings)
 - mukmoux lard is called mukmoux-fat
 
 KING TODO:


### PR DESCRIPTION
## What?

    - Changed internal name of "dirty-water-light" to "tailings".
    - Changed internal name of "dirty-water-heavy" to "muddy-water".
    
## Why?

    - This has always annoyed me.
    - Fixes https://github.com/pyanodon/pybugreports/issues/1076
    
Changelog & migration are present in pycoalprocessing.
All similarly named PRs must be merged at the same time!