### PR TITLE
Buff rare earch mining drills 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,8 @@ Date: ????
   Changes:
     - Added recipes to convert steam and pressurized steam into cooler forms
     - Hid the vanilla beacon entity from selection menus, factoriopedia, and other GUIs
+    - Buff higher tiers of rare earth mining drills to have lower resource drain
+      and larger mining area
 ---------------------------------------------------------------------------------------------------
 Version: 3.1.32
 Date: 2025-08-12

--- a/prototypes/buildings/ree-mining-drill-mk02.lua
+++ b/prototypes/buildings/ree-mining-drill-mk02.lua
@@ -66,7 +66,8 @@ ENTITY {
     },
     energy_usage = "800kW",
     mining_power = 1,
-    resource_searching_radius = 3.49,
+    resource_searching_radius = 4.49,
+    resource_drain_rate_percent = 50,
     vector_to_place_result = {0, -2.65},
     radius_visualisation_picture = {
         filename = "__base__/graphics/entity/electric-mining-drill/electric-mining-drill-radius-visualization.png",

--- a/prototypes/buildings/ree-mining-drill-mk03.lua
+++ b/prototypes/buildings/ree-mining-drill-mk03.lua
@@ -65,7 +65,8 @@ ENTITY {
     },
     energy_usage = "1000kW",
     mining_power = 1,
-    resource_searching_radius = 3.49,
+    resource_searching_radius = 5.49,
+    resource_drain_rate_percent = 25,
     vector_to_place_result = {0, -2.65},
     radius_visualisation_picture = {
         filename = "__base__/graphics/entity/electric-mining-drill/electric-mining-drill-radius-visualization.png",

--- a/prototypes/buildings/ree-mining-drill-mk04.lua
+++ b/prototypes/buildings/ree-mining-drill-mk04.lua
@@ -69,7 +69,8 @@ ENTITY {
     },
     energy_usage = "1200kW",
     mining_power = 1,
-    resource_searching_radius = 3.49,
+    resource_searching_radius = 6.49,
+    resource_drain_rate_percent = 12.5,
     vector_to_place_result = {0, -2.65},
     radius_visualisation_picture = {
         filename = "__base__/graphics/entity/electric-mining-drill/electric-mining-drill-radius-visualization.png",


### PR DESCRIPTION
Buff higher tiers of ree drills to have larger mining area and lower resource drain. Followed (roughly) the numbers for antimony:
- mk1: 7x7 area, 100% drain
- mk2: 9x9 area, 50% drain
- mk3: 11x11 area, 25% drain
- mk4: 13x13, 12.5% drain

Resolves part of https://github.com/pyanodon/pybugreports/issues/1182