### PR TITLE
Update hot-molten-salt recipe icons to make them easier to tell apart

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ Date: ???
     - Hid the vanilla beacon entity from selection menus, factoriopedia, and other GUIs
     - Removed barreling recipes for internal "void" and "solar-concentration" fluids.
     - Added Dutch locale (thanks, QatSquirrel!)
+    - Update hot-molten-salt recipe icons to make them easier to tell apart
 ---------------------------------------------------------------------------------------------------
 Version: 3.1.33
 Date: 2025-08-23

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -183,6 +183,23 @@ for _, name in pairs(electric_energy_interfaces) do
     entity.energy_source.buffer_capacity = entity.energy_production
 end
 
+local molten_salt_recipes = {
+    "biomass-molten-salt-0",
+    "coal-molten-salt-0",
+    "gas-molten-salt-0",
+    "oil-molten-salt-0",
+}
+-- Add the mk01..mk04 color bars to the hot-molten-salt recipes
+for _, name in pairs(molten_salt_recipes) do
+    for mk = 1, 4, 1 do
+        local recipe = name .. mk
+        table.insert(data.raw.recipe[recipe].icons, {
+            icon = "__pyalienlifegraphics__/graphics/icons/over-mk0" .. mk .. ".png",
+            icon_size = 64,
+        })
+    end
+end
+
 for _, resource in pairs(data.raw.resource) do
     if not resource.selection_priority then
         resource.selection_priority = 40

--- a/prototypes/recipes/recipes-biomassplant.lua
+++ b/prototypes/recipes/recipes-biomassplant.lua
@@ -11,6 +11,7 @@ RECIPE {
         {type = "fluid", name = "hot-molten-salt", amount = 400, temperature = 1000},
 
     },
+    icons = py.composite_icon("hot-molten-salt", "biomass"),
 }:add_unlock("biomassplant-mk01")
 
 RECIPE {
@@ -25,6 +26,7 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 400, temperature = 2000},
     },
+    icons = py.composite_icon("hot-molten-salt", "biomass"),
 }:add_unlock("biomassplant-mk02")
 
 RECIPE {
@@ -39,6 +41,7 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 400, temperature = 3000},
     },
+    icons = py.composite_icon("hot-molten-salt", "biomass"),
 }:add_unlock("biomassplant-mk03")
 
 RECIPE {
@@ -53,4 +56,5 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 400, temperature = 4000},
     },
+    icons = py.composite_icon("hot-molten-salt", "biomass"),
 }:add_unlock("biomassplant-mk04")

--- a/prototypes/recipes/recipes-coalplant.lua
+++ b/prototypes/recipes/recipes-coalplant.lua
@@ -10,6 +10,7 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 1000},
     },
+    icons = py.composite_icon("hot-molten-salt", "coal"),
 }:add_unlock("coalplant-mk01")
 
 RECIPE {
@@ -24,6 +25,7 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 2000},
     },
+    icons = py.composite_icon("hot-molten-salt", "coal"),
 }:add_unlock("coalplant-mk02")
 
 RECIPE {
@@ -38,6 +40,7 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 3000},
     },
+    icons = py.composite_icon("hot-molten-salt", "coal"),
 }:add_unlock("coalplant-mk03")
 
 RECIPE {
@@ -52,4 +55,5 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 4000},
     },
+    icons = py.composite_icon("hot-molten-salt", "coal"),
 }:add_unlock("coalplant-mk04")

--- a/prototypes/recipes/recipes-gasplant.lua
+++ b/prototypes/recipes/recipes-gasplant.lua
@@ -10,6 +10,7 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 1000},
     },
+    icons = py.composite_icon("hot-molten-salt", "natural-gas"),
 }:add_unlock("gasplant-mk01")
 
 RECIPE {
@@ -24,6 +25,7 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 2000},
     },
+    icons = py.composite_icon("hot-molten-salt", "refined-natural-gas"),
 }:add_unlock("gasplant-mk02")
 
 RECIPE {
@@ -38,6 +40,7 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 3000},
     },
+    icons = py.composite_icon("hot-molten-salt", "purified-natural-gas"),
 }:add_unlock("gasplant-mk03")
 
 RECIPE {
@@ -52,4 +55,5 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 4000},
     },
+    icons = py.composite_icon("hot-molten-salt", "pure-natural-gas"),
 }:add_unlock("gasplant-mk04")

--- a/prototypes/recipes/recipes-oilplant.lua
+++ b/prototypes/recipes/recipes-oilplant.lua
@@ -10,6 +10,7 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 1000},
     },
+    icons = py.composite_icon("hot-molten-salt", "kerosene"),
 }:add_unlock("oilplant-mk01")
 
 RECIPE {
@@ -24,6 +25,7 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 2000},
     },
+    icons = py.composite_icon("hot-molten-salt", "fuel-oil"),
 }:add_unlock("oilplant-mk02")
 
 RECIPE {
@@ -38,6 +40,7 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 3000},
     },
+    icons = py.composite_icon("hot-molten-salt", "diesel"),
 }:add_unlock("oilplant-mk03")
 
 RECIPE {
@@ -52,4 +55,5 @@ RECIPE {
     results = {
         {type = "fluid", name = "hot-molten-salt", amount = 500, temperature = 4000},
     },
+    icons = py.composite_icon("hot-molten-salt", "gasoline"),
 }:add_unlock("oilplant-mk04")

--- a/prototypes/recipes/recipes.lua
+++ b/prototypes/recipes/recipes.lua
@@ -771,6 +771,7 @@ RECIPE {
         {type = "fluid", name = "molten-salt", amount = 100, temperature = 1000},
     },
     --main_product = "eg-si",
+    icons = py.composite_icon("molten-salt", "salt"),
 }:add_unlock("energy-1")
 
 RECIPE {


### PR DESCRIPTION
Adds (one of) the plant fuel type(s) to the upper left of the icon as well as adding the mk01..mk04 color bar to the right.

<img width="400" alt="molten_salt_icons_old" src="https://github.com/user-attachments/assets/3ae8aa51-5a11-4de3-983e-97cd380a0a0c" />

<img width="400" alt="molten_salt_icons" src="https://github.com/user-attachments/assets/53401c18-77d4-4584-b933-0f60edcaaee6" />

