### PR TITLE
Buff Molten Erbium Nickel Cobalt Alloy

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 4.0.0
 Date: ???
   Changes:
+    - Erbium Nickel Cobalt Alloy 2 recipe now produces 5 alloy instead of 1.
     - Antimony Drills now display correct power consumption and dont allow efficency modules. Resolves https://github.com/pyanodon/pybugreports/issues/1007
     - Buffed the recipe speed of plutonium reshuffle by 4x.
     - Removed efficiency modules from power plants. Already placed modules will continue to work, but beacons won't.

--- a/prototypes/recipes/recipes-er.lua
+++ b/prototypes/recipes/recipes-er.lua
@@ -98,7 +98,7 @@ RECIPE {
         {type = "item",  name = "cobalt-sulfate-02", amount = 2},
     },
     results = {
-        {type = "item", name = "ernico", amount = 1},
+        {type = "item", name = "ernico", amount = 5},
     },
     --main_product = "eg-si",
 }:add_unlock("alloys-mk05")


### PR DESCRIPTION
New PR Against breaking-changes.

Current Erbium Nickel Cobalt recipe using molten nickel (ernico2) is quite bad, costing more molten nickel than the recipe 1 and keeping all other ingredients the same.  This gives the molten recipe a buff (Arbitrarily by a factor of 5), to make it more in line with the good gains from other molten recipes.  

<img width="564" height="357" alt="image" src="https://github.com/user-attachments/assets/beb1b99f-cc83-408e-945e-7efda3646b05" />
